### PR TITLE
Get service xaddrs from GetCapabilities instead of GetServices

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -234,10 +234,12 @@ class ONVIFCamera(object):
 
         # Get XAddr of services on the device
         self.xaddrs = { }
-        services = self.devicemgmt.GetServices({'IncludeCapability': False})
-        for item in services:
+        capabilities = self.devicemgmt.GetCapabilities({'CapabilityCategory': 'All'})
+        for name, capability in capabilities:
             try:
-                self.xaddrs[item['Namespace']] = item['XAddr']
+                if name.lower() in SERVICES:
+                    ns = SERVICES[name.lower()]['ns']
+                    self.xaddrs[ns] = capability['XAddr']
             except Exception:
                 logger.exception('Unexcept service type')
 

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -234,7 +234,7 @@ class ONVIFCamera(object):
 
         # Get XAddr of services on the device
         self.xaddrs = { }
-        capabilities = self.devicemgmt.GetCapabilities({'CapabilityCategory': 'All'})
+        capabilities = self.devicemgmt.GetCapabilities({'Category': 'All'})
         for name, capability in capabilities:
             try:
                 if name.lower() in SERVICES:


### PR DESCRIPTION
The ONVIF Profile S spec for cameras does not require implementation of the 'GetServices' method. Notably, Axis cameras do not implement it. Profile S does require implementation of 'GetCapabilities', which also lists service endpoints.