### PR TITLE
Allow not adding wsse to requests.

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -127,7 +127,9 @@ class ONVIFService(object):
         self.daemon = daemon
 
         self.dt_diff = dt_diff
-        self.set_wsse()
+
+        if self.user is not None and self.passwd is not None:
+            self.set_wsse()
 
         # Method to create type instance of service method defined in WSDL
         self.create_type = self.ws_client.factory.create


### PR DESCRIPTION
This is necessary for Profile Q Factory Default state.

ProfileQ- compliant devices are out of the box in factory default state. This implies that they may not have a default username and password.

With this modification, if username and password are None, the wsse is not added to the ONVIFClient and the library can interoperate with devices in factory default state.