### PR TITLE
Make class variables instance variables so multiple instances don't pollute each others' services

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -232,14 +232,13 @@ class ONVIFCamera(object):
     >>> ptz_service.GetConfiguration()
     '''
 
-    # Class-level variables
-    services_template = {'devicemgmt': None, 'ptz': None, 'media': None,
-                         'imaging': None, 'events': None, 'analytics': None }
-    use_services_template = {'devicemgmt': True, 'ptz': True, 'media': True,
-                         'imaging': True, 'events': True, 'analytics': True }
     def __init__(self, host, port ,user, passwd, wsdl_dir=os.path.join(os.path.dirname(os.path.dirname(__file__)), "wsdl"),
                  cache_location=None, cache_duration=None,
                  encrypt=True, daemon=False, no_cache=False, adjust_time=False):
+        self.services_template = {'devicemgmt': None, 'ptz': None, 'media': None,
+                         'imaging': None, 'events': None, 'analytics': None }
+        self.use_services_template = {'devicemgmt': True, 'ptz': True, 'media': True,
+                         'imaging': True, 'events': True, 'analytics': True }
         self.host = host
         self.port = int(port)
         self.user = user


### PR DESCRIPTION
I believe this addresses https://github.com/quatanium/python-onvif/issues/11, since the first camera created sets values for the class-level services variables and every camera after that receives those same values.

Easily tested (replacing the ip/ports/credentials below, obviously):

```
from onvif import ONVIFCamera
cam1 = ONVIFCamera('192.168.1.1', 80, 'user', 'pass')
for k, v in cam1.services_template:
    if v: print k, v.xaddr
# expect to see "devicemgmt http://192.168.1.1:80/onvif/device_service", etc

cam2 = ONVIFCamera('192.168.1.2', 80, 'user', 'pass')
for k, v in cam1.services_template:
    if v: print k, v.xaddr

# expect to see "devicemgmt http://192.168.1.2:80/onvif/device_service", etc
```

Without this commit, the values for cam2 would match cam1, which leads to the Bad Request errors.