### PR TITLE
Removing call to logging.basicConfig

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -7,7 +7,7 @@ from threading import Thread, RLock
 
 import logging
 logger = logging.getLogger('onvif')
-logging.basicConfig(level=logging.INFO)
+logger.setLevel(logging.INFO)
 logging.getLogger('suds.client').setLevel(logging.CRITICAL)
 
 import suds.sudsobject


### PR DESCRIPTION
This library makes a call to logging.basicConfig, which should really only be called in applications, not libraries. This causes any logging config that an application attempts to set to be overridden.
